### PR TITLE
Create centralized storage for Hive jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/suborbital/hive
 go 1.14
 
 require (
+	github.com/google/uuid v1.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/suborbital/grav v0.0.11
-	github.com/suborbital/vektor v0.1.2
+	github.com/suborbital/vektor v0.1.3
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -16,6 +18,8 @@ github.com/suborbital/vektor v0.1.1 h1:F3n9rS1F3nc+1Q2HZxeVNinvVkCRliVQ01+jRASct
 github.com/suborbital/vektor v0.1.1/go.mod h1:tJ4gA2P8NWC4Pdu0TgpSBWZHuZ1Qhp+r5RlsqyIqdyw=
 github.com/suborbital/vektor v0.1.2 h1:d4BvshbMl4wRVYPKO21vka7r89nlRrrZXidYQz07N9Q=
 github.com/suborbital/vektor v0.1.2/go.mod h1:tJ4gA2P8NWC4Pdu0TgpSBWZHuZ1Qhp+r5RlsqyIqdyw=
+github.com/suborbital/vektor v0.1.3 h1:rC5ic4FnjmcbizmV/WAQt67QkF6eJ7jHSsuy8IFC2bc=
+github.com/suborbital/vektor v0.1.3/go.mod h1:tJ4gA2P8NWC4Pdu0TgpSBWZHuZ1Qhp+r5RlsqyIqdyw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=

--- a/hive/hive.go
+++ b/hive/hive.go
@@ -23,9 +23,10 @@ type Hive struct {
 
 // New returns a Hive ready to accept Jobs
 func New() *Hive {
+	logger := vlog.Default()
 	h := &Hive{
-		scheduler: newScheduler(),
-		log:       vlog.Default(),
+		scheduler: newScheduler(logger),
+		log:       logger,
 	}
 
 	return h
@@ -41,10 +42,7 @@ func (h *Hive) Handle(jobType string, runner Runnable, options ...Option) JobFun
 	h.handle(jobType, runner, options...)
 
 	helper := func(data interface{}) *Result {
-		job := Job{
-			jobType: jobType,
-			data:    data,
-		}
+		job := NewJob(jobType, data)
 
 		return h.Do(job)
 	}
@@ -60,10 +58,7 @@ func (h *Hive) HandleMsg(pod *grav.Pod, msgType string, runner Runnable, options
 	h.handle(msgType, runner, options...)
 
 	helper := func(data interface{}) *Result {
-		job := Job{
-			jobType: msgType,
-			data:    data,
-		}
+		job := NewJob(msgType, data)
 
 		return h.Do(job)
 	}

--- a/hive/hive_test.go
+++ b/hive/hive_test.go
@@ -34,7 +34,7 @@ func TestHiveJob(t *testing.T) {
 
 	r := h.Do(h.Job("generic", "first"))
 
-	if r.ID == "" {
+	if r.UUID() == "" {
 		t.Error("result ID is empty")
 	}
 

--- a/hive/job.go
+++ b/hive/job.go
@@ -37,13 +37,13 @@ func NewJob(jobType string, data interface{}) Job {
 }
 
 // UUID returns the Job's UUID
-func (j *JobReference) UUID() string {
+func (j JobReference) UUID() string {
 	return j.uuid
 }
 
 // Reference returns a reference to the Job
-func (j Job) Reference() *JobReference {
-	return &j.JobReference
+func (j Job) Reference() JobReference {
+	return j.JobReference
 }
 
 // Unmarshal unmarshals the job's data into a struct

--- a/hive/server.go
+++ b/hive/server.go
@@ -89,7 +89,7 @@ func (s *Server) scheduleHandler() vk.HandlerFunc {
 		s.addInFlight(res)
 
 		resp := doResponse{
-			ResultID: res.ID,
+			ResultID: res.UUID(),
 		}
 
 		return resp, nil
@@ -155,7 +155,7 @@ func (s *Server) addInFlight(r *Result) {
 	s.Lock()
 	defer s.Unlock()
 
-	s.inFlight[r.ID] = r
+	s.inFlight[r.UUID()] = r
 }
 
 func (s *Server) getInFlight(id string) *Result {

--- a/hive/storage.go
+++ b/hive/storage.go
@@ -1,0 +1,92 @@
+package hive
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// ErrJobNotFound and others are storage realated errors
+var (
+	ErrJobNotFound = errors.New("job not found in storage")
+)
+
+// Storage represents a storage driver for Hive
+type Storage interface {
+	Add(Job) error
+	AddResult(string, interface{}, error) error
+	Get(string) (Job, error)
+	Remove(string) error
+}
+
+// MemoryStorage is the default in-memory storage driver for Hive
+type MemoryStorage struct {
+	jobs    sync.Map
+	results sync.Map
+	errors  sync.Map
+}
+
+// a function that can be given to a Result to remove a Job from storage once its result has been delivered
+type removeFunc func(string)
+
+func newMemoryStorage() *MemoryStorage {
+	m := &MemoryStorage{
+		jobs:    sync.Map{},
+		results: sync.Map{},
+		errors:  sync.Map{},
+	}
+
+	return m
+}
+
+// Add adds a Job to storage
+func (m *MemoryStorage) Add(job Job) error {
+	// store as a pointer
+	m.jobs.Store(job.UUID(), &job)
+
+	return nil
+}
+
+// AddResult adds a Job result to storage
+func (m *MemoryStorage) AddResult(uuid string, data interface{}, err error) error {
+	if err != nil {
+		m.errors.Store(uuid, err.Error())
+	} else {
+		m.results.Store(uuid, data)
+	}
+
+	return nil
+}
+
+// Get loads a Job and any of its results from storage
+func (m *MemoryStorage) Get(uuid string) (Job, error) {
+	rawJob, ok := m.jobs.Load(uuid)
+	if !ok {
+		return Job{}, ErrJobNotFound
+	}
+
+	// cast to pointer as loadResult has a pointer receiver
+	job := rawJob.(*Job)
+
+	res, _ := m.results.Load(uuid)
+
+	var errString string
+
+	rawErr, ok := m.errors.Load(uuid)
+	if ok {
+		errString = rawErr.(string)
+	}
+
+	job.loadResult(res, errString)
+
+	return *job, nil
+}
+
+// Remove removes a Job and its data from storage
+func (m *MemoryStorage) Remove(uuid string) error {
+	m.jobs.Delete(uuid)
+	m.results.Delete(uuid)
+	m.errors.Delete(uuid)
+
+	return nil
+}

--- a/hive/worker.go
+++ b/hive/worker.go
@@ -21,7 +21,7 @@ var (
 
 type worker struct {
 	runner   Runnable
-	workChan chan *JobReference
+	workChan chan JobReference
 	store    Storage
 	options  workerOpts
 
@@ -35,7 +35,7 @@ type worker struct {
 func newWorker(runner Runnable, store Storage, opts workerOpts) *worker {
 	w := &worker{
 		runner:     runner,
-		workChan:   make(chan *JobReference, defaultChanSize),
+		workChan:   make(chan JobReference, defaultChanSize),
 		store:      store,
 		options:    opts,
 		threads:    make([]*workThread, opts.poolSize),
@@ -48,7 +48,7 @@ func newWorker(runner Runnable, store Storage, opts workerOpts) *worker {
 	return w
 }
 
-func (w *worker) schedule(job *JobReference) {
+func (w *worker) schedule(job JobReference) {
 	go func() {
 		w.workChan <- job
 	}()
@@ -104,14 +104,14 @@ func (w *worker) isStarted() bool {
 
 type workThread struct {
 	runner         Runnable
-	workChan       chan *JobReference
+	workChan       chan JobReference
 	store          Storage
 	timeoutSeconds int
 	ctx            context.Context
 	cancelFunc     context.CancelFunc
 }
 
-func newWorkThread(runner Runnable, workChan chan *JobReference, store Storage, timeoutSeconds int) *workThread {
+func newWorkThread(runner Runnable, workChan chan JobReference, store Storage, timeoutSeconds int) *workThread {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	wt := &workThread{


### PR DESCRIPTION
This PR creates a Storage interface and implementation (in-memory)

Hive gets refactored to use this storage interface when creating jobs, and decouples the internal scheduler from the Job object by passing around a lightweight JobReference instead.